### PR TITLE
Update `johnpbloch/wordpress-core-installer` to `1.x`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "wordpress-install-dir": "web/wp"
     },
     "require": {
-        "johnpbloch/wordpress-core-installer": "~0.1"
+        "johnpbloch/wordpress-core-installer": "^1.0"
     },
     "license": [
         "GPL-2.0+"


### PR DESCRIPTION
Closes #3 