### PR TITLE
update wordpress-core-installer to ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "wordpress-install-dir": "web/wp"
     },
     "require": {
-        "johnpbloch/wordpress-core-installer": "~0.1"
+        "johnpbloch/wordpress-core-installer": "^2.0"
     },
     "license": [
         "GPL-2.0+"


### PR DESCRIPTION
The `wordpress-core-installer` package is incompatible with Composer 2.  This PR would upgrade that package to its version 2.0 so that this repo can be used with Composer 1 and 2.

This would obviate the need for #5 as it requests this package be upgraded to version 1.0.