### PR TITLE
Fix undefined WPRocketFix::remove().

### DIFF
--- a/wp-content/mu-plugins/pantheon-mu-plugin/inc/compatibility/fixes/class-wprocketfix.php
+++ b/wp-content/mu-plugins/pantheon-mu-plugin/inc/compatibility/fixes/class-wprocketfix.php
@@ -25,4 +25,9 @@ class WPRocketFix {
 		DefineConstantFix::apply( 'WP_ROCKET_CACHE_ROOT_URL',
 		sprintf( '%s/wp-content/uploads/wp-rocket/cache/', $home_url ) );
 	}
+
+	/**
+	 * @return void
+	 */
+	public static function remove() {}
 }


### PR DESCRIPTION
Issue: Fatal error: Uncaught Error: Call to undefined method Pantheon\Compatibility\Fixes\WPRocketFix::remove() in /code/web/wp-content/mu-plugins/pantheon-mu-plugin/inc/compatibility/class-wprocket.php:37 

WPRocket::remove_fix calls WPRocketFix::remove() which does not exist and hence this PR.

Steps to reproduce:
- Try to uninstall WP Rocket plugin.